### PR TITLE
Add feature to create the desired branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ steps:
 
 - **branch** (optional, defaults to `$BUILDKITE_BRANCH`)
 
-    The branch where changes will be committed. Since Buildkite runs builds in a detached HEAD state, this plugin will fetch and checkout the given branch prior to committing.
+    The branch where changes will be committed. Since Buildkite runs builds in a detached HEAD state, this plugin will fetch and checkout the given branch prior to committing. Unless we're creating a new branch. See `create-branch` below.
+
+- **create-branch** (optional, defaults to `false`)
+
+    When set to true the branch will be created, rather than fetched from the remote.
 
 - **message** (optional, defaults to `Build #${BUILDKITE_BUILD_NUMBER}`)
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -22,8 +22,13 @@ then
   git config user.email "$BUILDKITE_PLUGIN_GIT_COMMIT_USER_EMAIL"
 fi
 
-git fetch "$remote" "$branch:$branch"
-git checkout "$branch"
+if [[ ${BUILDKITE_PLUGIN_GIT_COMMIT_CREATE_BRANCH:-false} = "true" ]]
+then
+  git checkout -b "$branch"
+else
+  git fetch "$remote" "$branch:$branch"
+  git checkout "$branch"
+fi
 git add -A "${BUILDKITE_PLUGIN_GIT_COMMIT_ADD:-.}"
 
 if ! git diff-index --quiet HEAD

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,6 +8,8 @@ configuration:
       type: string
     branch:
       type: string
+    create-branch:
+      type: boolean
     message:
       type: string
     remote:

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -114,6 +114,28 @@ post_command_hook="$PWD/hooks/post-command"
   unstub git
 }
 
+@test "Creates and pushes to a specific branch" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_BRANCH=master
+
+  export BUILDKITE_PLUGIN_GIT_COMMIT_BRANCH=code-orange
+  export BUILDKITE_PLUGIN_GIT_COMMIT_CREATE_BRANCH=true
+
+  stub git \
+    "checkout -b code-orange : echo checkout" \
+    "add -A . : echo add" \
+    "diff-index --quiet HEAD : false" \
+    "commit -m \"Build #1\" : echo commit" \
+    "push origin code-orange : echo push"
+
+  run "$post_command_hook"
+
+  assert_success
+  assert_output --partial "--- Committing changes"
+  assert_output --partial "--- Pushing to origin"
+  unstub git
+}
+
 @test "Allows a custom message" {
   export BUILDKITE_BUILD_NUMBER=1
   export BUILDKITE_BRANCH=master


### PR DESCRIPTION
I have a use-case where the branch to commit to doesn't yet exist. It would be nice is this plugin could optionally create the specified branch.

I've added the option `create-branch`. When set to `true`, the plugin will create the specified branch. Before committing changes as usual.