### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With no options, commits all changed/added files to `$BUILDKITE_BRANCH` and push
 steps:
   - command: make
     plugins:
-      thedyrt/git-commit#v0.3.0: ~
+      - thedyrt/git-commit#v0.3.0: ~
 ```
 
 With all options customized:
@@ -21,15 +21,15 @@ With all options customized:
 steps:
   - command: make
     plugins:
-      thedyrt/git-commit#v0.3.0:
-        add: app/
-        branch: my-branch
-        create-branch: true
-        message: "Updated data [$BUILDKITE_BUILD_NUMBER]"
-        remote: upstream
-        user:
-          name: Reid
-          email: reid@example.com
+      - thedyrt/git-commit#v0.3.0:
+          add: app/
+          branch: my-branch
+          create-branch: true
+          message: "Updated data [$BUILDKITE_BUILD_NUMBER]"
+          remote: upstream
+          user:
+            name: Reid
+            email: reid@example.com
 ```
 
 ## Configuration


### PR DESCRIPTION
Hi @reidab! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.